### PR TITLE
fix break curve duplicate class name define

### DIFF
--- a/OpenMEP/OpenMEP.csproj
+++ b/OpenMEP/OpenMEP.csproj
@@ -97,21 +97,6 @@
         <FolderPackages>$(Appdata)\Dynamo\Dynamo Revit\$(BuildOutput)\packages\OpenMEP\</FolderPackages>
         <GenerateDocumentationFile>True</GenerateDocumentationFile>
     </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)' == 'Debug R20' ">
-      <DefineConstants>TRACE;R20;DEBUG;</DefineConstants>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)' == 'Debug R21' ">
-      <DefineConstants>TRACE;R21;DEBUG;</DefineConstants>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)' == 'Debug R22' ">
-      <DefineConstants>TRACE;R22;DEBUG;</DefineConstants>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)' == 'Debug R23' ">
-      <DefineConstants>TRACE;R23;DEBUG;</DefineConstants>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)' == 'Debug R23.1' ">
-      <DefineConstants>TRACE;R23;R23;DEBUG;</DefineConstants>
-    </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Chuongmep.Revit.Api.RevitAPI" Version="$(RevitVersion).*">
             <ExcludeAssets>runtime</ExcludeAssets>

--- a/OpenMEP/OpenMEP.csproj
+++ b/OpenMEP/OpenMEP.csproj
@@ -97,6 +97,21 @@
         <FolderPackages>$(Appdata)\Dynamo\Dynamo Revit\$(BuildOutput)\packages\OpenMEP\</FolderPackages>
         <GenerateDocumentationFile>True</GenerateDocumentationFile>
     </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Debug R20' ">
+      <DefineConstants>TRACE;R20;DEBUG;</DefineConstants>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Debug R21' ">
+      <DefineConstants>TRACE;R21;DEBUG;</DefineConstants>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Debug R22' ">
+      <DefineConstants>TRACE;R22;DEBUG;</DefineConstants>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Debug R23' ">
+      <DefineConstants>TRACE;R23;DEBUG;</DefineConstants>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Debug R23.1' ">
+      <DefineConstants>TRACE;R23;R23;DEBUG;</DefineConstants>
+    </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Chuongmep.Revit.Api.RevitAPI" Version="$(RevitVersion).*">
             <ExcludeAssets>runtime</ExcludeAssets>
@@ -110,9 +125,9 @@
         <PackageReference Include="DynamoVisualProgramming.Revit" Version="$(DynamoVersion).*">
             <ExcludeAssets>runtime</ExcludeAssets>
         </PackageReference>
-        <Reference Include="System.Net.Http"/>
-        <PackageReference Include="GShark" Version="2.1.0"/>
-        <PackageReference Include="Microsoft.CSharp" Version="4.7.0"/>
+        <Reference Include="System.Net.Http" />
+        <PackageReference Include="GShark" Version="2.1.0" />
+        <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     </ItemGroup>
     <ItemGroup>
         <EmbeddedResource Update="Resources\OpenMEPImages.resx">
@@ -128,31 +143,31 @@
         </Compile>
     </ItemGroup>
     <ItemGroup>
-        <Folder Include="Application\Dynamo"/>
-        <Folder Include="Application\Revit"/>
-        <Folder Include="Application\Windows"/>
+        <Folder Include="Application\Dynamo" />
+        <Folder Include="Application\Revit" />
+        <Folder Include="Application\Windows" />
     </ItemGroup>
     <Target Name="CopyFiles" AfterTargets="CoreBuild">
         <ItemGroup>
-            <AssemblyFiles Include="$(TargetDir)*.*"/>
-            <PgkDefinition Include="$(SolutionDir)docs\pkg.json"/>
-            <XmlCustomization Include="$(SolutionDir)docs\*.xml"/>
-            <ExtralFiles Include="$(SolutionDir)docs\extra\*.*"/>
-            <DyfFiles Include="$(SolutionDir)docs\dyf\*.*"/>
+            <AssemblyFiles Include="$(TargetDir)*.*" />
+            <PgkDefinition Include="$(SolutionDir)docs\pkg.json" />
+            <XmlCustomization Include="$(SolutionDir)docs\*.xml" />
+            <ExtralFiles Include="$(SolutionDir)docs\extra\*.*" />
+            <DyfFiles Include="$(SolutionDir)docs\dyf\*.*" />
         </ItemGroup>
-        <Message Text="Copying From $(TargetDir) To $(FolderPackages)" Importance="high"/>
-        <Copy SourceFiles="@(AssemblyFiles)" DestinationFolder="$(FolderPackages)bin"/>
-        <Copy SourceFiles="@(XmlCustomization)" DestinationFolder="$(FolderPackages)bin"/>
-        <Copy SourceFiles="@(PgkDefinition)" DestinationFolder="$(FolderPackages)"/>
-        <Copy SourceFiles="@(ExtralFiles)" DestinationFolder="$(FolderPackages)extra"/>
-        <Copy SourceFiles="@(DyfFiles)" DestinationFolder="$(FolderPackages)dyf"/>
-        <Message Text="Copied Completed" Importance="high"/>
+        <Message Text="Copying From $(TargetDir) To $(FolderPackages)" Importance="high" />
+        <Copy SourceFiles="@(AssemblyFiles)" DestinationFolder="$(FolderPackages)bin" />
+        <Copy SourceFiles="@(XmlCustomization)" DestinationFolder="$(FolderPackages)bin" />
+        <Copy SourceFiles="@(PgkDefinition)" DestinationFolder="$(FolderPackages)" />
+        <Copy SourceFiles="@(ExtralFiles)" DestinationFolder="$(FolderPackages)extra" />
+        <Copy SourceFiles="@(DyfFiles)" DestinationFolder="$(FolderPackages)dyf" />
+        <Message Text="Copied Completed" Importance="high" />
     </Target>
     <Target Name="GenerateCustomization" BeforeTargets="Build">
         <GetReferenceAssemblyPaths TargetFrameworkMoniker=".NETFramework, Version=v4.8">
-            <Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="FrameworkAssembliesPath"/>
+            <Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="FrameworkAssembliesPath" />
         </GetReferenceAssemblyPaths>
-        <GenerateResource SdkToolsPath="$(TargetFrameworkSDKToolsDirectory)" UseSourcePath="true" Sources="$(ProjectDir)\Resources\OpenMEPimages.resx" OutputResources="$(ProjectDir)\Resources\OpenMEPimages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll"/>
-        <AL SdkToolsPath="$(TargetFrameworkSDKToolsDirectory)" TargetType="library" EmbedResources="$(ProjectDir)\Resources\OpenMEPimages.resources" OutputAssembly="$(TargetDir)OpenMEP.customization.dll"/>
+        <GenerateResource SdkToolsPath="$(TargetFrameworkSDKToolsDirectory)" UseSourcePath="true" Sources="$(ProjectDir)\Resources\OpenMEPimages.resx" OutputResources="$(ProjectDir)\Resources\OpenMEPimages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll" />
+        <AL SdkToolsPath="$(TargetFrameworkSDKToolsDirectory)" TargetType="library" EmbedResources="$(ProjectDir)\Resources\OpenMEPimages.resources" OutputAssembly="$(TargetDir)OpenMEP.customization.dll" />
     </Target>
 </Project>


### PR DESCRIPTION
### Purpose

Problem cause when name of class duplicate with name of class Revit API

### Description

![Revit_3iS0zOzWlA](https://user-images.githubusercontent.com/31106432/220385646-e7c11212-e756-4019-9d4b-16255122f4d7.png)

### Declarations

Check these if you believe they are true

- [x] This PR fix bug
- [ ] This PR for new feature
- [ ] The codebase is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
